### PR TITLE
Allow specifying a custom matcher

### DIFF
--- a/src/main/java/com/palominolabs/metrics/guice/MetricsInstrumentationModule.java
+++ b/src/main/java/com/palominolabs/metrics/guice/MetricsInstrumentationModule.java
@@ -6,6 +6,8 @@ import com.codahale.metrics.annotation.Gauge;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matcher;
 import com.google.inject.matcher.Matchers;
 
 /**
@@ -21,21 +23,31 @@ import com.google.inject.matcher.Matchers;
  * @see GaugeInjectionListener
  */
 public class MetricsInstrumentationModule extends AbstractModule {
-
     private final MetricRegistry metricRegistry;
+    private final Matcher<? super TypeLiteral<?>> matcher;
 
     /**
      * @param metricRegistry The registry to use when creating meters, etc. for annotated methods.
      */
     public MetricsInstrumentationModule(MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
+        this.matcher = Matchers.any();
+    }
+
+    /**
+     * @param metricRegistry The registry to use when creating meters, etc. for annotated methods.
+     * @param matcher The matcher to determine which types to look for metrics in
+     */
+    public MetricsInstrumentationModule(MetricRegistry metricRegistry, Matcher<? super TypeLiteral<?>> matcher) {
+        this.metricRegistry = metricRegistry;
+        this.matcher = matcher;
     }
 
     @Override
     protected void configure() {
-        bindListener(Matchers.any(), new MeteredListener(metricRegistry));
-        bindListener(Matchers.any(), new TimedListener(metricRegistry));
-        bindListener(Matchers.any(), new GaugeListener(metricRegistry));
-        bindListener(Matchers.any(), new ExceptionMeteredListener(metricRegistry));
+        bindListener(matcher, new MeteredListener(metricRegistry));
+        bindListener(matcher, new TimedListener(metricRegistry));
+        bindListener(matcher, new GaugeListener(metricRegistry));
+        bindListener(matcher, new ExceptionMeteredListener(metricRegistry));
     }
 }

--- a/src/test/java/com/palominolabs/metrics/guice/MatcherTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/MatcherTest.java
@@ -1,0 +1,67 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.AbstractMatcher;
+import com.google.inject.matcher.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class MatcherTest {
+    private InstrumentedWithTimed timedInstance;
+    private InstrumentedWithMetered meteredInstance;
+    private MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Matcher<? super TypeLiteral<?>> matcher = new AbstractMatcher<TypeLiteral<?>>() {
+            @Override
+            public boolean matches(final TypeLiteral<?> typeLiteral) {
+                return InstrumentedWithMetered.class.isAssignableFrom(typeLiteral.getRawType());
+            }
+        };
+        final Injector injector = Guice.createInjector(new MetricsInstrumentationModule(registry, matcher));
+        this.timedInstance = injector.getInstance(InstrumentedWithTimed.class);
+        this.meteredInstance = injector.getInstance(InstrumentedWithMetered.class);
+    }
+
+    @Test
+    public void aTimedAnnotatedMethod() throws Exception {
+
+        timedInstance.doAThing();
+
+        final Timer metric = registry.getTimers().get(name(InstrumentedWithTimed.class,
+            "things"));
+
+        assertThat("Guice did not create a metric for timed",
+                   metric,
+                   is(nullValue()));
+    }
+
+    @Test
+    public void aMeteredAnnotatedMethod() throws Exception {
+
+        meteredInstance.doAThing();
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "things"));
+
+        assertThat("Guice creates a metric",
+                   metric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a meter which gets marked",
+                   metric.getCount(),
+                   is(1L));
+    }
+}


### PR DESCRIPTION
We've been having problems using metrics-guice in DropWizard. Since we create the resources via guice, they are processed by metrics-guice before being handed over to Jersey. Unfortunately guice does not propagate annotations to the proxy and so Jersey does not thing the resources are in fact resources. See also https://groups.google.com/forum/#!msg/dropwizard-user/YA7pR5n_QUo/2Nk4IhKhIIMJ and 
https://github.com/dropwizard/metrics/issues/315 for additional info.

This change allows to specify a custom matcher when installing the metrics-guice module which allows us to 'hide' the resources from metrics-guice (and have metrics-jersey handle them instead).
