### PR TITLE
Add a default suffix to the metric name

### DIFF
--- a/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
+++ b/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
@@ -43,7 +43,7 @@ class GaugeListener implements TypeListener {
         }
 
         if (annotation.name().isEmpty()) {
-            return MetricRegistry.name(klass, method.getName(), annotation.name());
+            return MetricRegistry.name(klass, method.getName(), Gauge.class.getSimpleName());
         }
 
         return MetricRegistry.name(klass, annotation.name());

--- a/src/main/java/com/palominolabs/metrics/guice/MeteredInterceptor.java
+++ b/src/main/java/com/palominolabs/metrics/guice/MeteredInterceptor.java
@@ -29,7 +29,7 @@ class MeteredInterceptor implements MethodInterceptor {
         }
 
         if (annotation.name().isEmpty()) {
-            return MetricRegistry.name(klass, method.getName(), annotation.name());
+            return MetricRegistry.name(klass, method.getName(), Metered.class.getSimpleName());
         }
 
         return MetricRegistry.name(klass, annotation.name());

--- a/src/main/java/com/palominolabs/metrics/guice/TimedInterceptor.java
+++ b/src/main/java/com/palominolabs/metrics/guice/TimedInterceptor.java
@@ -26,9 +26,9 @@ class TimedInterceptor implements MethodInterceptor {
         if (annotation.absolute()) {
             return annotation.name();
         }
-
+        
         if (annotation.name().isEmpty()) {
-            return MetricRegistry.name(klass, method.getName(), annotation.name());
+            return MetricRegistry.name(klass, method.getName(), Timed.class.getSimpleName());
         }
 
         return MetricRegistry.name(klass, annotation.name());

--- a/src/test/java/com/palominolabs/metrics/guice/ExceptionMeteredTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/ExceptionMeteredTest.java
@@ -4,8 +4,11 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -270,7 +273,7 @@ public class ExceptionMeteredTest {
     public void aMethodAnnotatedWithBothATimerAndAnExceptionCounter() throws Exception {
 
         final Timer timedMetric = registry.getTimers().get(name(InstrumentedWithExceptionMetered.class,
-                                                               "timedAndException"));
+                                                               "timedAndException", Timed.class.getSimpleName()));
 
         final Meter errorMetric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
                                                                "timedAndException", DEFAULT_NAME_SUFFIX));
@@ -332,7 +335,7 @@ public class ExceptionMeteredTest {
     public void aMethodAnnotatedWithBothAMeteredAndAnExceptionCounter() throws Exception {
 
         final Metric meteredMetric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
-                                                                 "meteredAndException"));
+                                                                 "meteredAndException", Metered.class.getSimpleName()));
 
         final Metric errorMetric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
                                                                "meteredAndException", DEFAULT_NAME_SUFFIX));

--- a/src/test/java/com/palominolabs/metrics/guice/GaugeTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/GaugeTest.java
@@ -1,17 +1,17 @@
 package com.palominolabs.metrics.guice;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 
 public class GaugeTest {
     private InstrumentedWithGauge instance;
@@ -47,7 +47,7 @@ public class GaugeTest {
         instance.doAnotherThing();
 
         final Gauge metric = registry.getGauges().get(name(InstrumentedWithGauge.class,
-                                                                       "doAnotherThing"));
+                                                                       "doAnotherThing", Gauge.class.getSimpleName()));
 
         assertThat("Guice creates a metric",
                    metric,

--- a/src/test/java/com/palominolabs/metrics/guice/MeteredTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/MeteredTest.java
@@ -2,8 +2,10 @@ package com.palominolabs.metrics.guice;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Metered;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +42,7 @@ public class MeteredTest {
     @Test
     public void aMeteredAnnotatedMethodWithDefaultScope() throws Exception {
 
-        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "doAThingWithDefaultScope"));
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "doAThingWithDefaultScope", Metered.class.getSimpleName()));
         assertMetricIsSetup(metric);
 
         assertThat("Metric initialises to zero",
@@ -57,7 +59,7 @@ public class MeteredTest {
     @Test
     public void aMeteredAnnotatedMethodWithProtectedScope() throws Exception {
 
-        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "doAThingWithProtectedScope"));
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "doAThingWithProtectedScope", Metered.class.getSimpleName()));
 
         assertMetricIsSetup(metric);
 

--- a/src/test/java/com/palominolabs/metrics/guice/TimedTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/TimedTest.java
@@ -2,6 +2,7 @@ package com.palominolabs.metrics.guice;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -45,7 +46,7 @@ public class TimedTest {
         instance.doAThingWithDefaultScope();
 
         final Timer metric = registry.getTimers().get(name(InstrumentedWithTimed.class,
-                                                                       "doAThingWithDefaultScope"));
+                                                                       "doAThingWithDefaultScope", Timed.class.getSimpleName()));
 
         assertMetricSetup(metric);
     }
@@ -56,7 +57,7 @@ public class TimedTest {
         instance.doAThingWithProtectedScope();
 
         final Timer metric = registry.getTimers().get(name(InstrumentedWithTimed.class,
-                                                                       "doAThingWithProtectedScope"));
+                                                                       "doAThingWithProtectedScope", Timed.class.getSimpleName()));
 
         assertMetricSetup(metric);
     }


### PR DESCRIPTION
When you annotate a method with multiple metric annotations, and then inject it, the injection fails with a message about the metrics having the same name.

This pull request adds a suffix to the default metric name of the annotation. I didn't do it for exception metrics, because that one already has a suffix that should suffice.
