### PR TITLE
metrics-servlet optional to make metrics-guice functional in a non web environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-servlets</artifactId>
             <version>${metrics.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>


### PR DESCRIPTION
Hi guys !
It should be perfect if metrics-servlet was optional too to allow metrics-guice to be used in a non web environment.
Here is the modification...
Thanks!

Hugo
