### PR TITLE
fix for private method  annotation  not working for  gauge

### DIFF
--- a/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
+++ b/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
@@ -23,7 +23,7 @@ public class GaugeListener implements TypeListener {
     @Override
     public <I> void hear(final TypeLiteral<I> literal, TypeEncounter<I> encounter) {
         Class<? super I> klass = literal.getRawType();
-        for (final Method method : klass.getMethods()) {
+        for (final Method method : klass.getDeclaredMethods()) {
             final Gauge annotation = method.getAnnotation(Gauge.class);
             if (annotation != null) {
                 if (method.getParameterTypes().length == 0) {


### PR DESCRIPTION
getMethods() only gets the public method.