### PR TITLE
Enhance MetricNamer to allow better gauge name customization

### DIFF
--- a/src/main/java/com/palominolabs/metrics/guice/DefaultMetricNamer.java
+++ b/src/main/java/com/palominolabs/metrics/guice/DefaultMetricNamer.java
@@ -55,7 +55,7 @@ public class DefaultMetricNamer implements MetricNamer {
 
     @Nonnull
     @Override
-    public String getNameForGauge(@Nonnull Method method, @Nonnull Gauge gauge) {
+    public String getNameForGauge(@Nonnull Class<?> klass, @Nonnull Method method, @Nonnull Gauge gauge) {
         if (gauge.absolute()) {
             return gauge.name();
         }

--- a/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
+++ b/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
@@ -25,7 +25,8 @@ public class GaugeListener implements TypeListener {
 
     @Override
     public <I> void hear(final TypeLiteral<I> literal, TypeEncounter<I> encounter) {
-        Class<? super I> klass = literal.getRawType();
+        final Class<? super I> literalKlass = literal.getRawType();
+        Class<? super I> klass = literalKlass;
 
         do {
             for (Method method : klass.getDeclaredMethods()) {
@@ -36,7 +37,7 @@ public class GaugeListener implements TypeListener {
                 final Gauge annotation = annotationResolver.findAnnotation(Gauge.class, method);
                 if (annotation != null) {
                     if (method.getParameterTypes().length == 0) {
-                        final String metricName = metricNamer.getNameForGauge(method, annotation);
+                        final String metricName = metricNamer.getNameForGauge(literalKlass, method, annotation);
 
                         if (!method.isAccessible()) {
                             method.setAccessible(true);

--- a/src/main/java/com/palominolabs/metrics/guice/MetricNamer.java
+++ b/src/main/java/com/palominolabs/metrics/guice/MetricNamer.java
@@ -21,7 +21,7 @@ public interface MetricNamer {
     String getNameForExceptionMetered(@Nonnull Method method, @Nonnull ExceptionMetered exceptionMetered);
 
     @Nonnull
-    String getNameForGauge(@Nonnull Method method, @Nonnull Gauge gauge);
+    String getNameForGauge(@Nonnull Class<?> klass, @Nonnull Method method, @Nonnull Gauge gauge);
 
     @Nonnull
     String getNameForMetered(@Nonnull Method method, @Nonnull Metered metered);

--- a/src/test/java/com/palominolabs/metrics/guice/GaugeClassicTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/GaugeClassicTest.java
@@ -1,0 +1,131 @@
+package com.palominolabs.metrics.guice;
+
+import java.lang.reflect.Method;
+
+import javax.annotation.Nonnull;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.palominolabs.metrics.guice.DefaultMetricNamer.GAUGE_SUFFIX;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+@SuppressWarnings("unchecked")
+public class GaugeClassicTest
+{
+    private InstrumentedWithGauge instance;
+    private MetricRegistry registry;
+
+    private static class ClassicMetricNamer extends DefaultMetricNamer {
+        @Nonnull
+        @Override
+        public String getNameForGauge(@Nonnull final Class<?> klass,
+                                      @Nonnull final Method method,
+                                      @Nonnull final com.codahale.metrics.annotation.Gauge gauge)
+        {
+            if (gauge.absolute()) {
+                return gauge.name();
+            }
+
+            if (gauge.name().isEmpty()) {
+                return name(klass, method.getName(), GAUGE_SUFFIX);
+            }
+
+            return name(klass, gauge.name());
+        }
+    }
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).withMetricNamer(new ClassicMetricNamer()).build());
+        this.instance = injector.getInstance(InstrumentedWithGauge.class);
+    }
+
+    @Test
+    public void aGaugeAnnotatedMethod() throws Exception {
+        instance.doAThing();
+
+        final Gauge metric = registry.getGauges().get(name(InstrumentedWithGauge.class, "things"));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a gauge with the given value",
+            ((Gauge<String>) metric).getValue(),
+            is("poop"));
+    }
+
+    @Test
+    public void aGaugeAnnotatedMethodWithDefaultName() throws Exception {
+        instance.doAnotherThing();
+
+        final Gauge metric = registry.getGauges().get(name(InstrumentedWithGauge.class,
+            "doAnotherThing", GAUGE_SUFFIX));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a gauge with the given value",
+            ((Gauge<String>) metric).getValue(),
+            is("anotherThing"));
+    }
+
+    @Test
+    public void aGaugeAnnotatedMethodWithAbsoluteName() throws Exception {
+        instance.doAThingWithAbsoluteName();
+
+        final Gauge metric = registry.getGauges().get(name("absoluteName"));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a gauge with the given value",
+            ((Gauge<String>) metric).getValue(),
+            is("anotherThingWithAbsoluteName"));
+    }
+
+    @Test
+    public void aGaugeWithoutNameInSuperclass() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name(InstrumentedWithGauge.class,"justAGaugeFromParent", GAUGE_SUFFIX));
+
+        assertNotNull(metric);
+        assertEquals("justAGaugeFromParent", metric.getValue());
+    }
+
+    @Test
+    public void aGaugeInSuperclass() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name("gaugeParent"));
+
+        assertNotNull(metric);
+        assertEquals("gaugeParent", metric.getValue());
+    }
+
+    @Test
+    public void aPrivateGaugeInSuperclass() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name("gaugeParentPrivate"));
+
+        assertNotNull(metric);
+        assertEquals("gaugeParentPrivate", metric.getValue());
+    }
+
+    @Test
+    public void aPrivateGauge() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name(InstrumentedWithGauge.class, "gaugePrivate"));
+
+        assertNotNull(metric);
+        assertEquals("gaugePrivate", metric.getValue());
+    }
+}

--- a/src/test/java/com/palominolabs/metrics/guice/GaugeTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/GaugeTest.java
@@ -74,6 +74,14 @@ public class GaugeTest {
     }
 
     @Test
+    public void aGaugeWithoutNameInSuperclass() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name(InstrumentedWithGaugeParent.class,"justAGaugeFromParent", GAUGE_SUFFIX));
+
+        assertNotNull(metric);
+        assertEquals("justAGaugeFromParent", metric.getValue());
+    }
+
+    @Test
     public void aGaugeInSuperclass() throws Exception {
         final Gauge<?> metric = registry.getGauges().get(name("gaugeParent"));
 

--- a/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithGaugeParent.java
+++ b/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithGaugeParent.java
@@ -8,6 +8,11 @@ class InstrumentedWithGaugeParent {
         return "gaugeParent";
     }
 
+    @Gauge
+    public String justAGaugeFromParent() {
+        return "justAGaugeFromParent";
+    }
+
     @Gauge(name = "gaugeParentPrivate", absolute = true)
     private String gaugeParentPrivate() {
         return "gaugeParentPrivate";


### PR DESCRIPTION
Gauges from superclasses work, and we use them extensively. Still, current `MetricNamer` does not allow to customise naming of them.

Here, method `MetricNamer#getNameForGauge` is enhanced, that allows customisation we need.