### PR TITLE
Add withMetricRegistryProvider support

### DIFF
--- a/src/main/java/com/palominolabs/metrics/guice/CountedListener.java
+++ b/src/main/java/com/palominolabs/metrics/guice/CountedListener.java
@@ -6,19 +6,21 @@ import com.codahale.metrics.annotation.Counted;
 import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
 import java.lang.reflect.Method;
 import javax.annotation.Nullable;
+import javax.inject.Provider;
+
 import org.aopalliance.intercept.MethodInterceptor;
 
 /**
  * A listener which adds method interceptors to counted methods.
  */
 public class CountedListener extends DeclaredMethodsTypeListener {
-    private final MetricRegistry metricRegistry;
+    private final Provider<MetricRegistry> metricRegistryProvider;
     private final MetricNamer metricNamer;
     private final AnnotationResolver annotationResolver;
 
-    public CountedListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+    public CountedListener(Provider<MetricRegistry> metricRegistryProvider, MetricNamer metricNamer,
             AnnotationResolver annotationResolver) {
-        this.metricRegistry = metricRegistry;
+        this.metricRegistryProvider = metricRegistryProvider;
         this.metricNamer = metricNamer;
         this.annotationResolver = annotationResolver;
     }
@@ -28,6 +30,7 @@ public class CountedListener extends DeclaredMethodsTypeListener {
     protected MethodInterceptor getInterceptor(Method method) {
         final Counted annotation = annotationResolver.findAnnotation(Counted.class, method);
         if (annotation != null) {
+            final MetricRegistry metricRegistry = metricRegistryProvider.get();
             final Counter counter = metricRegistry.counter(metricNamer.getNameForCounted(method, annotation));
             return new CountedInterceptor(counter, annotation);
         }

--- a/src/main/java/com/palominolabs/metrics/guice/ExceptionMeteredListener.java
+++ b/src/main/java/com/palominolabs/metrics/guice/ExceptionMeteredListener.java
@@ -6,19 +6,21 @@ import com.codahale.metrics.annotation.ExceptionMetered;
 import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
 import java.lang.reflect.Method;
 import javax.annotation.Nullable;
+import javax.inject.Provider;
+
 import org.aopalliance.intercept.MethodInterceptor;
 
 /**
  * A listener which adds method interceptors to methods that should be instrumented for exceptions
  */
 public class ExceptionMeteredListener extends DeclaredMethodsTypeListener {
-    private final MetricRegistry metricRegistry;
+    private final Provider<MetricRegistry> metricRegistryProvider;
     private final MetricNamer metricNamer;
     private final AnnotationResolver annotationResolver;
 
-    public ExceptionMeteredListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+    public ExceptionMeteredListener(Provider<MetricRegistry> metricRegistryProvider, MetricNamer metricNamer,
             final AnnotationResolver annotationResolver) {
-        this.metricRegistry = metricRegistry;
+        this.metricRegistryProvider = metricRegistryProvider;
         this.metricNamer = metricNamer;
         this.annotationResolver = annotationResolver;
     }
@@ -28,6 +30,7 @@ public class ExceptionMeteredListener extends DeclaredMethodsTypeListener {
     protected MethodInterceptor getInterceptor(Method method) {
         final ExceptionMetered annotation = annotationResolver.findAnnotation(ExceptionMetered.class, method);
         if (annotation != null) {
+            final MetricRegistry metricRegistry = metricRegistryProvider.get();
             final Meter meter = metricRegistry.meter(metricNamer.getNameForExceptionMetered(method, annotation));
             return new ExceptionMeteredInterceptor(meter, annotation.cause());
         }

--- a/src/main/java/com/palominolabs/metrics/guice/MeteredListener.java
+++ b/src/main/java/com/palominolabs/metrics/guice/MeteredListener.java
@@ -6,19 +6,21 @@ import com.codahale.metrics.annotation.Metered;
 import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
 import java.lang.reflect.Method;
 import javax.annotation.Nullable;
+import javax.inject.Provider;
+
 import org.aopalliance.intercept.MethodInterceptor;
 
 /**
  * A listener which adds method interceptors to metered methods.
  */
 public class MeteredListener extends DeclaredMethodsTypeListener {
-    private final MetricRegistry metricRegistry;
+    private final Provider<MetricRegistry> metricRegistryProvider;
     private final MetricNamer metricNamer;
     private final AnnotationResolver annotationResolver;
 
-    public MeteredListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+    public MeteredListener(Provider<MetricRegistry> metricRegistryProvider, MetricNamer metricNamer,
             AnnotationResolver annotationResolver) {
-        this.metricRegistry = metricRegistry;
+        this.metricRegistryProvider = metricRegistryProvider;
         this.metricNamer = metricNamer;
         this.annotationResolver = annotationResolver;
     }
@@ -28,6 +30,7 @@ public class MeteredListener extends DeclaredMethodsTypeListener {
     protected MethodInterceptor getInterceptor(Method method) {
         final Metered annotation = annotationResolver.findAnnotation(Metered.class, method);
         if (annotation != null) {
+            final MetricRegistry metricRegistry = metricRegistryProvider.get();
             final Meter meter = metricRegistry.meter(metricNamer.getNameForMetered(method, annotation));
             return new MeteredInterceptor(meter);
         }

--- a/src/main/java/com/palominolabs/metrics/guice/TimedListener.java
+++ b/src/main/java/com/palominolabs/metrics/guice/TimedListener.java
@@ -6,19 +6,21 @@ import com.codahale.metrics.annotation.Timed;
 import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
 import java.lang.reflect.Method;
 import javax.annotation.Nullable;
+import javax.inject.Provider;
+
 import org.aopalliance.intercept.MethodInterceptor;
 
 /**
  * A listener which adds method interceptors to timed methods.
  */
 public class TimedListener extends DeclaredMethodsTypeListener {
-    private final MetricRegistry metricRegistry;
+    private final Provider<MetricRegistry> metricRegistryProvider;
     private final MetricNamer metricNamer;
     private final AnnotationResolver annotationResolver;
 
-    public TimedListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+    public TimedListener(Provider<MetricRegistry> metricRegistryProvider, MetricNamer metricNamer,
             final AnnotationResolver annotationResolver) {
-        this.metricRegistry = metricRegistry;
+        this.metricRegistryProvider = metricRegistryProvider;
         this.metricNamer = metricNamer;
         this.annotationResolver = annotationResolver;
     }
@@ -28,6 +30,7 @@ public class TimedListener extends DeclaredMethodsTypeListener {
     protected MethodInterceptor getInterceptor(Method method) {
         final Timed annotation = annotationResolver.findAnnotation(Timed.class, method);
         if (annotation != null) {
+            final MetricRegistry metricRegistry = metricRegistryProvider.get();
             final Timer timer = metricRegistry.timer(metricNamer.getNameForTimed(method, annotation));
             return new TimedInterceptor(timer);
         }

--- a/src/test/java/com/palominolabs/metrics/guice/CountedTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/CountedTest.java
@@ -22,7 +22,8 @@ public class CountedTest {
     @Before
     public void setup() {
         this.registry = new MetricRegistry();
-        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
+        final Injector injector = Guice.createInjector(
+                MetricsInstrumentationModule.builder().withMetricRegistryProvider(() -> registry).build());
         this.instance = injector.getInstance(InstrumentedWithCounter.class);
     }
 

--- a/src/test/java/com/palominolabs/metrics/guice/GaugeInheritanceTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/GaugeInheritanceTest.java
@@ -15,9 +15,9 @@ public class GaugeInheritanceTest {
         MetricRegistry registry = new MetricRegistry();
         final Injector injector = Guice
                 .createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
-        Parent parent = injector.getInstance(Parent.class);
-        Child1 child1 = injector.getInstance(Child1.class);
-        Child2 child2 = injector.getInstance(Child2.class);
+        injector.getInstance(Parent.class);
+        injector.getInstance(Child1.class);
+        injector.getInstance(Child2.class);
 
         // gauge in parent class is registered separately for each
 

--- a/src/test/java/com/palominolabs/metrics/guice/GaugeTestBase.java
+++ b/src/test/java/com/palominolabs/metrics/guice/GaugeTestBase.java
@@ -37,7 +37,7 @@ public abstract class GaugeTestBase {
     public void aGaugeAnnotatedMethod() throws Exception {
         instance.doAThing();
 
-        final Gauge metric = registry.getGauges().get(name(InstrumentedWithGauge.class, "things"));
+        final Gauge<?> metric = registry.getGauges().get(name(InstrumentedWithGauge.class, "things"));
 
         assertThat("Guice creates a metric",
                 metric,
@@ -52,7 +52,7 @@ public abstract class GaugeTestBase {
     public void aGaugeAnnotatedMethodWithDefaultName() throws Exception {
         instance.doAnotherThing();
 
-        final Gauge metric = registry.getGauges().get(name(InstrumentedWithGauge.class,
+        final Gauge<?> metric = registry.getGauges().get(name(InstrumentedWithGauge.class,
                 "doAnotherThing", GAUGE_SUFFIX));
 
         assertThat("Guice creates a metric",
@@ -68,7 +68,7 @@ public abstract class GaugeTestBase {
     public void aGaugeAnnotatedMethodWithAbsoluteName() throws Exception {
         instance.doAThingWithAbsoluteName();
 
-        final Gauge metric = registry.getGauges().get(name("absoluteName"));
+        final Gauge<?> metric = registry.getGauges().get(name("absoluteName"));
 
         assertThat("Guice creates a metric",
                 metric,

--- a/src/test/java/com/palominolabs/metrics/guice/MyException.java
+++ b/src/test/java/com/palominolabs/metrics/guice/MyException.java
@@ -2,4 +2,5 @@ package com.palominolabs.metrics.guice;
 
 public class MyException extends RuntimeException {
 
+    private static final long serialVersionUID = 1L;
 }

--- a/src/test/java/com/palominolabs/metrics/guice/annotation/ClassAnnotationResolverTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/annotation/ClassAnnotationResolverTest.java
@@ -35,6 +35,7 @@ public class ClassAnnotationResolverTest {
     @Timed
     @Metered
     @Counted
+    @SuppressWarnings("unused")
     private static class TypeLevelAnnotatedClass {
         public void publicMethod() {
         }

--- a/src/test/java/com/palominolabs/metrics/guice/annotation/ListAnnotationResolverTest.java
+++ b/src/test/java/com/palominolabs/metrics/guice/annotation/ListAnnotationResolverTest.java
@@ -47,6 +47,7 @@ public class ListAnnotationResolverTest {
     }
 
     @Timed
+    @SuppressWarnings("unused")
     private static class MixedAnnotatedClass {
         public void publicMethod() {
         }


### PR DESCRIPTION
Currently metrics-guice expects MetricsRegistry instance while configuring module, this improvement supports two additional methods for module configuration:
1) Default - it just expects MetricsRegistry to be available in injector
2) Now it is possible to supply Provider<MetricsRegistry>instead of instance

Usually class instances are not created in Guice configuration phase and/or there are cases when registry has to be crated using some other information, which is obtained (through @Inject) only after configuration phase.